### PR TITLE
Add hypothesis strategy for testing ISO-8601 round-trip of cftime objects

### DIFF
--- a/xarray/testing/strategies.py
+++ b/xarray/testing/strategies.py
@@ -1,3 +1,5 @@
+import datetime
+import warnings
 from collections.abc import Hashable, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, overload
 
@@ -8,6 +10,7 @@ from hypothesis.errors import InvalidArgument
 import xarray as xr
 from xarray.core.types import T_DuckArray
 from xarray.core.utils import attempt_import
+from xarray.tests.test_coding_times import _all_cftime_date_types
 
 if TYPE_CHECKING:
     from xarray.core.types import _DTypeLikeNested, _ShapeLike
@@ -473,3 +476,34 @@ def unique_subset_of(
     return (
         {k: objs[k] for k in subset_keys} if isinstance(objs, Mapping) else subset_keys
     )
+
+
+class CFTimeStategy(st.SearchStrategy):
+    def __init__(self, min_value, max_value):
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def do_draw(self, data):
+        unit_microsecond = datetime.timedelta(microseconds=1)
+        timespan_microseconds = (self.max_value - self.min_value) // unit_microsecond
+        result = data.draw_integer(0, timespan_microseconds)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*date/calendar/year zero.*")
+            return self.min_value + datetime.timedelta(microseconds=result)
+
+
+class CFTimeStrategyISO8601(st.SearchStrategy):
+    def __init__(self):
+        self.date_types = _all_cftime_date_types()
+        self.calendars = list(self.date_types)
+
+    def do_draw(self, data):
+        calendar = data.draw(st.sampled_from(self.calendars))
+        date_type = self.date_types[calendar]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*date/calendar/year zero.*")
+            daysinmonth = date_type(99999, 12, 1).daysinmonth
+            min_value = date_type(-99999, 1, 1)
+            max_value = date_type(99999, 12, daysinmonth, 23, 59, 59, 999999)
+            strategy = CFTimeStategy(min_value, max_value)
+            return strategy.do_draw(data)


### PR DESCRIPTION
This PR adds a hypothesis strategy for drawing cftime objects of any calendar type between the dates of `-99999-01-01` and `99999-12-DDT23:59:59.999999` (the maximum day depends on the calendar type).

cc: @dcherian

This is my first time writing a hypothesis strategy, so let me know if you have any tips / suggestions.  The core of it is a bit simpler than [the strategy for generating standard library `datetime.datetime` objects](https://github.com/HypothesisWorks/hypothesis/blob/82504838248fcd7f127e4f0fafa2d892f64a2f8a/hypothesis-python/src/hypothesis/strategies/_internal/datetime.py#L162-L217).  I broke things up into a basic strategy—one that generates datetimes within a certain range—and one specific to the ISO-8601 round-trip test, since I can imagine use-cases where we might want to change the minimum and maximum values and / or have tighter control over the calendar.