### PR TITLE
Implement `time_unit` option for `decode_cf_timedelta`

### DIFF
--- a/xarray/coding/times.py
+++ b/xarray/coding/times.py
@@ -610,7 +610,7 @@ def decode_cf_timedelta(
     num_timedeltas, units: str, time_unit: str = "ns"
 ) -> np.ndarray:
     """Given an array of numeric timedeltas in netCDF format, convert it into a
-    numpy timedelta64 {"s", "ms", "us", "ns"} array.
+    numpy timedelta64 ["s", "ms", "us", "ns"] array.
     """
     num_timedeltas = np.asarray(num_timedeltas)
     unit = _netcdf_to_numpy_timeunit(units)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -34,7 +34,6 @@ from xarray.coding.times import (
     format_cftime_datetime,
     infer_datetime_units,
     infer_timedelta_units,
-    to_timedelta_unboxed,
 )
 from xarray.coding.variables import SerializationWarning
 from xarray.conventions import _update_bounds_attributes, cf_encoder
@@ -635,7 +634,7 @@ def test_cf_timedelta(timedeltas, units, numbers) -> None:
     if timedeltas == "NaT":
         timedeltas = np.timedelta64("NaT", "ns")
     else:
-        timedeltas = to_timedelta_unboxed(timedeltas)
+        timedeltas = pd.to_timedelta(timedeltas).to_numpy()
     numbers = np.array(numbers)
 
     expected = numbers
@@ -659,7 +658,7 @@ def test_cf_timedelta_2d() -> None:
     units = "days"
     numbers = np.atleast_2d([1, 2, 3])
 
-    timedeltas = np.atleast_2d(to_timedelta_unboxed(["1D", "2D", "3D"]))
+    timedeltas = np.atleast_2d(pd.to_timedelta(["1D", "2D", "3D"]).to_numpy())
     expected = timedeltas
 
     actual = decode_cf_timedelta(numbers, units)

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -631,11 +631,10 @@ def test_infer_cftime_datetime_units(calendar, date_args, expected) -> None:
     ],
 )
 def test_cf_timedelta(timedeltas, units, numbers) -> None:
-    time_unit = "ns"
     if timedeltas == "NaT":
-        timedeltas = np.timedelta64("NaT", time_unit)
+        timedeltas = np.timedelta64("NaT", "ns")
     else:
-        timedeltas = pd.to_timedelta(timedeltas).as_unit(time_unit).to_numpy()
+        timedeltas = pd.to_timedelta(timedeltas).to_numpy()
     numbers = np.array(numbers)
 
     expected = numbers
@@ -645,12 +644,12 @@ def test_cf_timedelta(timedeltas, units, numbers) -> None:
 
     if units is not None:
         expected = timedeltas
-        actual = decode_cf_timedelta(numbers, units, time_unit)
+        actual = decode_cf_timedelta(numbers, units)
         assert_array_equal(expected, actual)
         assert expected.dtype == actual.dtype
 
-    expected = np.timedelta64("NaT", time_unit)
-    actual = decode_cf_timedelta(np.array(np.nan), "days", time_unit)
+    expected = np.timedelta64("NaT", "ns")
+    actual = decode_cf_timedelta(np.array(np.nan), "days")
     assert_array_equal(expected, actual)
     assert expected.dtype == actual.dtype
 


### PR DESCRIPTION
My main remaining concern with #9618 is that timedelta decoding / encoding is inconsistent with what is done for datetimes, i.e.:
- It is possible to decode into non-nanosecond resolution timedelta values without specifying the `time_unit`, which would be a breaking change, e.g.:
```
>>> times = [1, 2, 3]
>>> xr.coding.times.decode_cf_timedelta(times, "seconds")
array([1, 2, 3], dtype='timedelta64[s]')
```
- Encoding large non-nanosecond resolution timedelta values can silently lead to overflow, e.g.:
```
>>> time = np.timedelta64(300 * 365, "D").astype("timedelta64[s]")
>>> xr.coding.times.encode_cf_timedelta(time)
(array(-9223372036854775808), 'nanoseconds')
```

I have not yet gone the step of exposing the option to change the `time_unit` through `CFTimedeltaCoder` through the `decode_timedelta` argument, but this PR implements what *I think* is needed to bring the internals of non-nanosecond timedelta decoding / encoding up to speed with datetime decoding / encoding (I can do that later if you want).

Similar to datetime decoding, the default behavior is to always return nanosecond resolution values, or raise an error if this would lead to overflow.  As in datetime decoding, if a `time_unit` is specified that is coarser than the encoded timedeltas, the `time_unit` is updated to prevent precision loss.  

I added a few tests, which exercise this aspect of the code, including some that check overflow-safety and others that check we can accurately roundtrip large timedeltas.  With these changes the above examples work as expected:

```
>>> times = [1, 2, 3]
>>> xr.coding.times.decode_cf_timedelta(times, "seconds")
array([1000000000, 2000000000, 3000000000], dtype='timedelta64[ns]')
```

```
>>> time = np.timedelta64(300 * 365, "D").astype("timedelta64[s]")
>>> xr.coding.times.encode_cf_timedelta(time)
(array(109500), 'days')
```